### PR TITLE
Warn when sex not specified in register_dataset()

### DIFF
--- a/R/datasets.R
+++ b/R/datasets.R
@@ -57,6 +57,9 @@ register_dataset <- function(name, shortname=NULL, species=NULL,
   if(is.null(shortname))
     shortname=unname(abbreviate(name, minlength = 2))
 
+  if(missing(sex) && is.null(baselist[['sex']]))
+    warning("No sex specified for dataset: ", name,
+            ". Defaulting to 'F'. Please set sex explicitly.")
   sex=match.arg(sex)
 
   if(is.null(idfun))

--- a/tests/testthat/test-datasets.R
+++ b/tests/testthat/test-datasets.R
@@ -11,5 +11,13 @@ test_that("dataset support", {
   expect_silent(register_dataset('flywirex', shortname = 'fx', namespace = 'testthat', inherits = 'flywire'))
   expect_equal(dataset_details('flywirex', namespace = 'testthat')$sex, 'F')
 
+  # warning when sex not specified
+  expect_warning(
+    register_dataset('nosex', shortname = 'ns', namespace = 'testthat'),
+    "No sex specified"
+  )
+  # still defaults to F
+  expect_equal(dataset_details('nosex', namespace = 'testthat')$sex, 'F')
+
   remove_namespace('testthat')
 })


### PR DESCRIPTION
## Summary
- Add warning when `sex` parameter is not explicitly provided to `register_dataset()`
- Skip warning when inheriting from a dataset that already has sex defined
- Add tests for warning behavior

This helps ensure datasets are registered with complete metadata.

🤖 Generated with [Claude Code](https://claude.ai/code)